### PR TITLE
Rewrote the async/await calls in 04-lookup-carrier and added eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,16 @@
+const config = {
+  extends: 'airbnb',
+  parser: 'babel-eslint',
+  plugins: ['babel'],
+  rules: {
+    'no-console': 0,
+    'generator-star-spacing': 0,
+    'babel/generator-star-spacing': [2, { before: false, after: true }],
+    'global-require': 0
+  },
+  settings: {
+    'import/core-modules': ['electron']
+  }
+};
+
+module.exports = config;

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 copy-of-114th-congressional-contacts.xls
 testTwilioAPI.js
 asyncExample/
+build/

--- a/04-lookup-carrier.js
+++ b/04-lookup-carrier.js
@@ -1,14 +1,13 @@
 const fs = require('fs');
-const d3  = require('d3-dsv');
+const d3 = require('d3-dsv');
 const _ = require('lodash');
 const csvWriter = require('csv-write-stream');
-const async = require('asyncawait/async');
-const await = require('asyncawait/await');
 
 // Download the Node helper library from twilio.com/docs/node/install
 // accountSid and authToken from twilio.com/user/account
 // https://www.twilio.com/docs/api/lookups
 const LookupsClient = require('twilio').LookupsClient;
+
 const client = new LookupsClient(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
 
 const csvfile = 'memberCells.csv';
@@ -21,73 +20,75 @@ const d = inputData[0];
 
 // convert to E.164 format https://en.wikipedia.org/wiki/E.164
 const withoutDashes = d.memberCell.replace(/-/g, '');
-const E164Number =  `+1${withoutDashes}`;
+const E164Number = `+1${withoutDashes}`;
 // console.log('withoutDashes', withoutDashes);
 // console.log('E164Number', E164Number);
 
 // get the carrier data from the twilio API
-const getCarrierMetadata = async (function () {
-  await (function () {
-    client.phoneNumbers(E164Number).get({
-      type: 'carrier'
-    }, function (error, number) {
-      const response = {};
-      if (error) { console.log('error', error) };
-      console.log('carrier response from twilio API', number);
-      response.carrierErrorCode = number.carrier.error_code;
-      response.carrierType = number.carrier.type;
-      response.carrierName = number.carrier.name;
-      response.mobileNetworkCode = number.carrier.mobile_network_code;
-      response.mobileCountryCode = number.carrier.mobile_country_code;
-      return response;
+async function getCarrierMetadata() {
+  try {
+    const number = await client.phoneNumbers(E164Number).get({
+      type: 'carrier',
     });
-  });
-})
-    
-// also get the caller name data from the twilio API
-const getCallerMetadata = async (function () {
-  await (function () {
-    client.phoneNumbers(E164Number).get({
-      type: 'caller-name'
-    }, function (error, number) {
-      const response = {};
-      if (error) { console.log('error', error) };
-      console.log('caller-name response from  twilio API', number);
-      response.callerNameErrorCode = number.caller_name.error_code;
-      response.callerName = number.caller_name.caller_name;
-      response.callerType = number.caller_name.caller_name;
-      return response;
-    });
-  })
-})
 
-const program = async (function () {
+    const response = {};
+    console.log('carrier response from twilio API', number);
+    response.carrierErrorCode = number.carrier.error_code;
+    response.carrierType = number.carrier.type;
+    response.carrierName = number.carrier.name;
+    response.mobileNetworkCode = number.carrier.mobile_network_code;
+    response.mobileCountryCode = number.carrier.mobile_country_code;
+    return response;
+  } catch (e) {
+    return e;
+  }
+}
+
+// also get the caller name data from the twilio API
+async function getCallerMetadata() {
+  try {
+    const number = await client.phoneNumbers(E164Number).get({
+      type: 'caller-name',
+    });
+
+    const response = {};
+    console.log('caller-name response from  twilio API', number);
+    response.callerNameErrorCode = number.caller_name.error_code;
+    response.callerName = number.caller_name.caller_name;
+    response.callerType = number.caller_name.caller_name;
+    return response;
+  } catch (e) {
+    return e;
+  }
+}
+
+async function program() {
   let result = _.assign({}, d);
   console.log('result', result);
-  try  {
-    const carrierResponse = await(getCarrierMetadata());
+  try {
+    const carrierResponse = await getCarrierMetadata();
     result = _.assign(result, carrierResponse);
     console.log('carrierResponse result', result);
-    const callerResponse = await(getCallerMetadata());
+    const callerResponse = await getCallerMetadata();
     result = _.assign(result, callerResponse);
     console.log('callerResponse result', result);
-  } catch (ex) {
-    console.log('Caught an error');
+
+    return result;
+  } catch (e) {
+    return e;
   }
-  console.log('program result after try catch', result);
-  return result;
-})
+}
 
 // Execute program() and print the result.
-program().then(function (result) {
+program().then((result) => {
   enrichedData.push(result);
   console.log('enrichedData', enrichedData);
   const outputData = enrichedData;
   // write a csv file
   const writer = csvWriter();
   writer.pipe(fs.createWriteStream('memberCellsCarriers.csv'));
-  outputData.forEach(d => {
-    writer.write(d);
-  })
+  outputData.forEach(item => {
+    writer.write(item);
+  });
   writer.end();
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "some scripts for analyzing congressional contacts data",
   "main": "00-get-data.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "babel *.js --out-dir build"
   },
   "author": "@micahstubbs <micahstubbs@gmail.com> (https://github.com/micahstubbs)",
   "license": "CC0-1.0",
@@ -13,9 +14,19 @@
     "babel-cli": "^6.11.4",
     "babel-preset-es2017": "^1.6.1",
     "csv-write-stream": "^2.0.0",
+    "d3-dsv": "^1.0.1",
     "lodash": "^4.15.0",
     "request-promise": "^4.1.1",
     "twilio": "^2.9.2",
     "xlsx": "^0.8.0"
+  },
+  "devDependencies": {
+    "babel-eslint": "^6.1.2",
+    "eslint": "^3.3.1",
+    "eslint-config-airbnb": "^10.0.1",
+    "eslint-plugin-babel": "^3.3.0",
+    "eslint-plugin-import": "^1.13.0",
+    "eslint-plugin-jsx-a11y": "^2.1.0",
+    "eslint-plugin-react": "^6.1.1"
   }
 }


### PR DESCRIPTION
You're already using Babel and the ES2017 preset, so `async/await` should work out of the box, and don't need to require it in. 

To await a function, it must return a promise, and it must be inside an `async` function. You were putting the async token outside the enclosure, causing Babel to throw a fit, so I moved it inside. Twilio's SDK returns a promise if you don't specify a callback, so I simply moved the callback logic outside of the callback into a try/catch block awaiting the result of the promise. 

It seems everything's working now, but probably worth taking a look to ensure it's doing what you want it to. 😄 

I also added `eslint` using the `airbnb` set of standards because I find it helps troubleshooting all this new-fangled ES2017 stuff.